### PR TITLE
fix(deps): Remove unused dependency `org.grails:grails-plugin-testing`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ dependencies {
 
 
   api "org.grails.plugins:fields:$fieldsVersion"
-  testImplementation "org.grails:grails-plugin-testing"
 
   console "org.grails:grails-console"
 }


### PR DESCRIPTION
The `org.grails:grails-plugin-testing` dependency is no longer in use and has been removed from the Grails core repository in commits grails/grails-core@e75bf0a3 and grails/grails-core@7e2f4ff4.

Closes: #111