### PR TITLE
@ScaffoldContoller and @ScaffoldService support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 *.ipr
 # Ignore Gradle GUI config
 gradle-app.setting
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,7 @@ dependencies {
   api "org.grails:grails-web-boot"
   api 'javax.servlet:javax.servlet-api'
 
-
   api "io.github.gpc:fields:$fieldsVersion"
-  testImplementation "org.grails:grails-plugin-testing"
 
   console "org.grails:grails-console"
 }

--- a/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolver.groovy
+++ b/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolver.groovy
@@ -2,6 +2,7 @@ package grails.plugin.scaffolding
 
 import grails.codegen.model.ModelBuilder
 import grails.io.IOUtils
+import grails.plugin.scaffolding.annotation.ScaffoldController
 import grails.util.BuildSettings
 import grails.util.Environment
 import groovy.text.GStringTemplateEngine
@@ -82,6 +83,14 @@ class ScaffoldingViewResolver extends GroovyPageViewResolver implements Resource
                 def controllerClass = webR.controllerClass
 
                 def scaffoldValue = controllerClass?.getPropertyValue("scaffold")
+                if (!scaffoldValue) {
+                    ScaffoldController scaffoldAnnotation = controllerClass?.clazz?.getAnnotation(ScaffoldController)
+                    scaffoldValue = scaffoldAnnotation?.domain()
+                    if (scaffoldValue == Void) {
+                        scaffoldValue = null
+                    }
+                }
+
                 if (scaffoldValue instanceof Class) {
                     def shortViewName = viewName.substring(viewName.lastIndexOf('/') + 1)
                     Resource res = null

--- a/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolver.groovy
+++ b/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolver.groovy
@@ -9,6 +9,7 @@ import groovy.text.GStringTemplateEngine
 import groovy.text.Template
 import groovy.transform.CompileStatic
 import org.grails.buffer.FastStringWriter
+import org.grails.compiler.scaffolding.ScaffoldingControllerInjector
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.grails.web.servlet.view.GroovyPageView
 import org.grails.web.servlet.view.GroovyPageViewResolver
@@ -16,6 +17,8 @@ import org.springframework.context.ResourceLoaderAware
 import org.springframework.core.io.*
 import org.springframework.web.servlet.View
 
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
 import java.util.concurrent.ConcurrentHashMap
 
 /**

--- a/src/main/groovy/grails/plugin/scaffolding/annotation/ScaffoldController.java
+++ b/src/main/groovy/grails/plugin/scaffolding/annotation/ScaffoldController.java
@@ -1,0 +1,13 @@
+package grails.plugin.scaffolding.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ScaffoldController {
+    Class<?> value() default Void.class;
+    Class<?> domain() default Void.class;
+}

--- a/src/main/groovy/grails/plugin/scaffolding/annotation/ScaffoldService.java
+++ b/src/main/groovy/grails/plugin/scaffolding/annotation/ScaffoldService.java
@@ -1,0 +1,13 @@
+package grails.plugin.scaffolding.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ScaffoldService {
+    Class<?> value() default Void.class;
+    Class<?> domain() default Void.class;
+}

--- a/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjector.groovy
+++ b/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjector.groovy
@@ -2,6 +2,7 @@ package org.grails.compiler.scaffolding
 
 import grails.compiler.ast.AstTransformer
 import grails.compiler.ast.GrailsArtefactClassInjector
+import grails.plugin.scaffolding.annotation.ScaffoldController
 import grails.rest.RestfulController
 import groovy.transform.CompileStatic
 import org.codehaus.groovy.ast.ClassHelper
@@ -13,6 +14,7 @@ import org.grails.compiler.injection.GrailsASTUtils
 import org.grails.compiler.web.ControllerActionTransformer
 import org.grails.core.artefact.ControllerArtefactHandler
 import org.grails.plugins.web.rest.transform.ResourceTransform
+
 /**
  * Transformation that turns a controller into a scaffolding controller at compile time of 'static scaffold = Foo'
  * is specified
@@ -41,22 +43,26 @@ class ScaffoldingControllerInjector implements GrailsArtefactClassInjector {
     @Override
     void performInjectionOnAnnotatedClass(SourceUnit source, ClassNode classNode) {
         def propertyNode = classNode.getProperty(PROPERTY_SCAFFOLD)
+        def annotationNode = classNode.getAnnotations(ClassHelper.make(ScaffoldController)).find()
 
         def expression = propertyNode?.getInitialExpression()
-        if(expression instanceof ClassExpression) {
-
-            ClassNode superClassNode = ClassHelper.make(RestfulController).getPlainNodeReference()
+        if (expression instanceof ClassExpression || annotationNode) {
+            ClassNode superClassNode = ClassHelper.make(annotationNode?.getMember("value")?.type?.getTypeClass()?:RestfulController).getPlainNodeReference()
             def currentSuperClass = classNode.getSuperClass()
-            if(currentSuperClass.equals( GrailsASTUtils.OBJECT_CLASS_NODE )) {
-                def domainClass = ((ClassExpression) expression).getType()
+            if (currentSuperClass.equals(GrailsASTUtils.OBJECT_CLASS_NODE)) {
+                def domainClass = expression? ((ClassExpression) expression).getType() : null
+                if (!domainClass) {
+                    domainClass = annotationNode.getMember("domain")?.type
+                    if (!domainClass) {
+                        GrailsASTUtils.error(source, classNode, "Scaffolded controller (${classNode.name}) with @ScaffoldController does not have domain class set.", true)
+                    }
+                }
                 classNode.setSuperClass(GrailsASTUtils.nonGeneric(superClassNode, domainClass))
                 new ResourceTransform().addConstructor(classNode, domainClass, false)
-            }
-            else if( ! currentSuperClass.isDerivedFrom(superClassNode)) {
+            } else if (!currentSuperClass.isDerivedFrom(superClassNode)) {
                GrailsASTUtils.error(source, classNode, "Scaffolded controllers (${classNode.name}) cannot extend other classes: ${currentSuperClass.getName()}", true)
             }
-        }
-        else if(propertyNode != null) {
+        } else if (propertyNode != null) {
             GrailsASTUtils.error(source, propertyNode, "The 'scaffold' property must refer to a domain class.", true)
         }
     }

--- a/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjector.groovy
+++ b/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjector.groovy
@@ -1,0 +1,71 @@
+package org.grails.compiler.scaffolding
+
+import grails.compiler.ast.AstTransformer
+import grails.compiler.ast.GrailsArtefactClassInjector
+import grails.plugin.scaffolding.annotation.ScaffoldService
+import groovy.transform.CompileStatic
+import org.codehaus.groovy.ast.ClassHelper
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.classgen.GeneratorContext
+import org.codehaus.groovy.control.SourceUnit
+import org.grails.compiler.injection.GrailsASTUtils
+import org.grails.core.artefact.ServiceArtefactHandler
+import org.grails.io.support.GrailsResourceUtils
+import org.grails.plugins.web.rest.transform.ResourceTransform
+
+import java.util.regex.Pattern
+
+/**
+ * Transformation that turns a service into a scaffolding service at compile time if '@ScaffoldService'
+ * is specified
+ *
+ * @author Scott Murphy Heiberg
+ * @since 5.1
+ */
+@AstTransformer
+@CompileStatic
+class ScaffoldingServiceInjector implements GrailsArtefactClassInjector {
+
+    final String[] artefactTypes = [ServiceArtefactHandler.TYPE] as String[]
+    public static Pattern SERVICE_PATTERN = Pattern.compile(".+/" +
+        GrailsResourceUtils.GRAILS_APP_DIR + "/services/(.+)Service\\.groovy");
+
+    @Override
+    void performInjection(SourceUnit source, GeneratorContext context, ClassNode classNode) {
+        performInjectionOnAnnotatedClass(source, classNode)
+    }
+
+    @Override
+    void performInjection(SourceUnit source, ClassNode classNode) {
+        performInjectionOnAnnotatedClass(source, classNode)
+    }
+
+    @Override
+    void performInjectionOnAnnotatedClass(SourceUnit source, ClassNode classNode) {
+        def annotationNode = classNode.getAnnotations(ClassHelper.make(ScaffoldService)).find()
+        if (annotationNode) {
+            ClassNode serviceClassNode = annotationNode?.getMember("value")?.type
+            Class serviceClass = serviceClassNode?.getTypeClass()
+            ClassNode superClassNode = ClassHelper.make(serviceClass).getPlainNodeReference()
+            ClassNode currentSuperClass = classNode.getSuperClass()
+            if (currentSuperClass.equals(GrailsASTUtils.OBJECT_CLASS_NODE)) {
+                def domainClass = annotationNode.getMember("domain")?.type
+                if (!domainClass) {
+                    domainClass = ScaffoldingControllerInjector.extractGenericDomainClass(serviceClassNode)
+                }
+                if (!domainClass) {
+                    GrailsASTUtils.error(source, classNode, "Scaffolded service (${classNode.name}) with @ScaffoldService does not have domain class set.", true)
+                }
+                classNode.setSuperClass(GrailsASTUtils.nonGeneric(superClassNode, domainClass))
+                new ResourceTransform().addConstructor(classNode, domainClass, false)
+            } else if (!currentSuperClass.isDerivedFrom(superClassNode)) {
+               GrailsASTUtils.error(source, classNode, "Scaffolded services (${classNode.name}) cannot extend other classes: ${currentSuperClass.getName()}", true)
+            }
+        }
+    }
+
+    @Override
+    boolean shouldInject(URL url) {
+        return url != null && SERVICE_PATTERN.matcher(url.getFile()).find()
+    }
+}


### PR DESCRIPTION
Adds support for the annotation`@ScaffoldController` which provides an alternative to the `static scaffold = Domain` approach. 
```groovy
@ScaffoldController(domain = User)
class UserController {}
```

It also empowers the developer to use their own base controller instead of being forced to use `RestController` which could be very limiting.  `RestController` does not encapsulate all necessary business logic and is completely divergent from the Service MVC model that is generated by this plugin.  With this annotation, developers can now use an extended RestController to fit their needs, or create an entirely different generic controller that is not related at all to RestController and more closely matches the type of controller that is generated by this plugin.

```groovy
@ScaffoldController(GenericAsyncController)
class UserController {
    static scaffold = User
}
```

```groovy
@ScaffoldController(value = SecuredGenericController, domain = User)
class UserController {}
```
