### PR TITLE
remove unused groovyVersion from gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 projectVersion=6.0.0-SNAPSHOT
 grailsVersion=7.0.0-M1
-groovyVersion=4.0.24
 
 org.gradle.caching=true
 org.gradle.daemon=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 projectVersion=6.0.0-SNAPSHOT
-grailsVersion=7.0.0-M1
+grailsVersion=7.0.0-SNAPSHOT
 
 org.gradle.caching=true
 org.gradle.daemon=true


### PR DESCRIPTION
Update to use grails 7.0.0-SNAPSHOT.  It was not updated after Grails 7.0.0-M1 release.